### PR TITLE
Add gaia-demo tag to build and install gaia for demo purpose

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -121,8 +121,7 @@ case "$1" in
 	;;
 
 "gaia-demo")
-	make -C gaia install-media-samples ADB="$ADB"
-	make -C gaia install-gaia EXCLUDED="uitest test-agent" ADB="$ADB" GAIA_DOMAIN="thisdomaindoesnotexist.org"
+	make -C gaia install-gaia ADB="$ADB" DEMO=1
 	exit $?
 	;;
 

--- a/flash.sh
+++ b/flash.sh
@@ -120,6 +120,12 @@ case "$1" in
 	exit $?
 	;;
 
+"gaia-demo")
+	make -C gaia install-media-samples ADB="$ADB"
+	make -C gaia install-gaia EXCLUDED="uitest test-agent" ADB="$ADB" GAIA_DOMAIN="thisdomaindoesnotexist.org"
+	exit $?
+	;;
+
 "gaia")
 	make -C gaia install-gaia ADB="$ADB"
 	exit $?

--- a/flash.sh
+++ b/flash.sh
@@ -121,7 +121,7 @@ case "$1" in
 	;;
 
 "gaia-demo")
-	make -C gaia install-gaia ADB="$ADB" DEMO=1
+	make -C gaia demo ADB="$ADB"
 	exit $?
 	;;
 


### PR DESCRIPTION
As title, gaia demo does three things:
1. install sample media
2. set GAIA_DOMAIN to thisdomaindoesnotexist.org
3. Filter 'uitest test-agent' apps in gaia (needs change gaia Makefile, I will comment this pull request later for the pull request of gaia)
