### PR TITLE
More run-gdb.sh improvements

### DIFF
--- a/run-gdb.sh
+++ b/run-gdb.sh
@@ -44,12 +44,15 @@ if [ "$1" = "attach" ]; then
 
    $ADB shell gdbserver :$GDB_PORT --attach $B2G_PID &
 else
-   [ -n "$1" ] && B2G_BIN=$1
+   if [ -n "$1" ]; then
+      B2G_BIN=$1
+      shift
+   fi
    [ -n "$MOZ_DEBUG_CHILD_PROCESS" ] && GDBSERVER_ENV="$GDBSERVER_ENV MOZ_DEBUG_CHILD_PROCESS=$MOZ_DEBUG_CHILD_PROCESS "
    [ -n "$MOZ_IPC_MESSAGE_LOG" ]     && GDBSERVER_ENV="$GDBSERVER_ENV MOZ_IPC_MESSAGE_LOG=$MOZ_IPC_MESSAGE_LOG "
    $ADB shell kill $B2G_PID
-   $ADB shell stop b2g
-   $ADB shell LD_LIBRARY_PATH=/system/b2g $GDBSERVER_ENV gdbserver --multi :$GDB_PORT $B2G_BIN &
+   [ "$B2G_BIN" = "/system/b2g/b2g" ] && $ADB shell stop b2g
+   $ADB shell LD_LIBRARY_PATH=/system/b2g $GDBSERVER_ENV gdbserver --multi :$GDB_PORT $B2G_BIN $@ &
 fi
 
 sleep 1


### PR DESCRIPTION
1. Command-line arguments can now be passed into a program to be debugged:
   |run-gdb.sh </path/to/a/program> <arg1 arg2 ... arg n>|
2. |adb shell stop b2g| is now only run if the debuggee is /system/b2g/b2g
