### PR TITLE
Script to create toolchains for tinderbox

### DIFF
--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+# This script will probably live in /scripts/ but life's easier
+# when work is done in the actual B2G root
+cd ..
+
+OUT_DIR=out
+
+. load-config.sh
+
+if [ -z $1 ] ; then
+    echo "Usage: $0 <version> [<toolchain_target>]" 1>&2
+    exit -1
+fi
+
+output=gonk-toolchain-$1
+manifest_file=sources.xml
+if [ -z $2 ] ; then
+    toolchain_target=$2
+else
+    toolchain_target=linux-x86
+fi
+
+rm -rf $output ; mkdir -p $output
+./gonk-misc/add-revision.py .repo/manifest.xml \
+        --output $manifest_file --force --b2g-path $B2G_DIR --tags
+
+if [ ! -d $OUT_DIR/target/product/$DEVICE ] ; then
+    echo "ERROR: you must build B2G before building a toolchain" 1>&2
+    exit -1
+fi
+
+# Important Directories
+for i in \
+    bionic \
+    external/stlport/stlport \
+    external/dbus \
+    frameworks/base/include \
+    frameworks/base/native/include \
+    frameworks/base/opengl/include \
+    frameworks/base/services/sensorservice \
+    hardware/libhardware/include \
+    hardware/libhardware_legacy/include \
+    ndk/sources/android/cpufeatures \
+    ndk/sources/cxx-stl/system/include \
+    ndk/sources/cxx-stl/stlport/stlport \
+    ndk/sources/cxx-stl/gabi++/include \
+    out/target/product/$DEVICE/obj/lib \
+    prebuilt/ndk/android-ndk-r4/platforms/android-8/arch-arm \
+    prebuilt/$toolchain_target/toolchain/arm-linux-androideabi-4.4.x \
+    system/core/include 
+do 
+    mkdir -p $output/$i
+    cp -r $i/* $output/$i
+done
+
+# Important Files
+for i in \
+    gonk-misc/Unicode.h \
+    system/vold/ResponseCode.h
+do
+    directory=$(dirname $i)
+    mkdir -p $output/$directory
+    cp $i $output/$directory/
+done
+
+tar cjf $output.tar.bz2 $output $manifest_file
+rm -rf $output
+
+echo "{ \"toolchain_tarball\": \"$(dirname `pwd`)/$output.tar.bz2\" }" 
+


### PR DESCRIPTION
This is a port of the logic in the old build system that lets us build a toolchain with the minimum set of dependencies for building gecko.

In order to get gecko building with the new build system, I had to include a different toolchain, add a couple of special headers and modify the mozconfig that's needed.

@cgjones or @mwu -- can you please sanity check that I have the correct things included in the tarball?
