### PR TITLE
Change url of script for homebrew

### DIFF
--- a/scripts/bootstrap-mac.sh
+++ b/scripts/bootstrap-mac.sh
@@ -379,7 +379,7 @@ install_homebrew() {
         )
     fi
 
-    installer_url="https://raw.github.com/mxcl/homebrew/master/Library/Contributions/install_homebrew.rb"
+    installer_url="https://raw.github.com/mxcl/homebrew/go"
 
     run_command curl -fsSL $installer_url -o $tmp_installer
     run_command ruby $tmp_installer


### PR DESCRIPTION
I fixed the URL for Setup of Homebrew in Mac script. Change of :
https://raw.github.com/mxcl/homebrew/master/Library/Contributions/install_homebrew.rb
for :
https://raw.github.com/mxcl/homebrew/go
