### PR TITLE
Allow setting the AOSP build variant with the VARIANT environment variable

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,8 @@
 
 . load-config.sh
 
-LUNCH=${LUNCH:-full_${DEVICE}-eng}
+VARIANT=${VARIANT:-eng}
+LUNCH=${LUNCH:-full_${DEVICE}-${VARIANT}}
 
 export USE_CCACHE=yes &&
 export GECKO_PATH &&


### PR DESCRIPTION
This allows us to build user or userdebug variants of B2G by simply executing:

```
$ VARIANT=user ./build.sh
```
