### PR TITLE
move code drop script to scripts directory fixes issue #117

### DIFF
--- a/scripts/code-drop.sh
+++ b/scripts/code-drop.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd ..
+
 . load-config.sh
 
 b2g_root=$(cd `dirname $0` ; pwd)


### PR DESCRIPTION
Move the code drop script to be stored in the scripts/ directory
