### PR TITLE
Run `repo init` only once.

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -8,8 +8,17 @@ repo_sync() {
 	else
 		BRANCH=$1
 	fi
-	rm -rf .repo/manifest* &&
-	$REPO init -u $GITREPO -b $BRANCH &&
+        # Only run `repo init` when it isn't already done
+        # on the given device branch
+	if [ ! -f .repo/inited ] || [ `cat .repo/inited` != $1 ]; then
+		rm -rf .repo/manifest* &&
+		$REPO init -u $GITREPO -b $BRANCH
+		if [ $? -ne 0 ]; then
+			echo Repo init failed
+			exit -1
+		fi
+                echo $1 > .repo/inited
+        fi
 	$REPO sync
 	ret=$?
 	if [ "$GITREPO" = "$GIT_TEMP_REPO" ]; then


### PR DESCRIPTION
Here is a patch in order to simplify newcomers life.
We only run delete already checkouted projects and execute `repo init` when it is strictly necessary:
- when `repo init` wasn't ever run completely. (never run or run with failures),
- when repo were inited for another device.

It is extremelly frustating to have to checkout ~10GB of data when you face some dumb error during extract-file.sh later done in this script.

Possible tweaks on this patch:
- Move this `/.repo/inited` to `/.inited` or `/inited`.
- Do `repo sync` only once, right after the `repo init`. But I'm not sure it make any sense to do that!

[I haven't verified this patch yet, a fresh empty checkout is currently running]
