### PR TITLE
Print explicit error when trying to config a phone or image already on B2G

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -132,6 +132,12 @@ esac
 
 if [ $? -ne 0 ]; then
 	echo Configuration failed
+	if [ -d ./backup-$1/system/b2g ]; then
+		echo " * Your phone or device backup is already using B2G."
+		echo " * Either connect a phone still using Android,"
+		echo " * or provide a backup image of a device on Android"
+		echo " * via 'ANDROIDFS_DIR' env variable."
+	fi
 	exit -1
 fi
 


### PR DESCRIPTION
Here is another issue I had. It wasn't really obvious why the config.sh script failed.
Me and David both tried to hack the extract_file.sh instead of realizing we were totally wrong!!

Even if it is explicitely mentioned in documentation it would be worth printing such explicit message.
