### PR TITLE
Initial mochitest frontend support in test.sh

### DIFF
--- a/load-config.sh
+++ b/load-config.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-B2G_DIR=$(cd `dirname $0`; pwd)
+if [[ ! -n "$B2G_DIR" ]]; then
+  B2G_DIR=$(cd `dirname $0`; pwd)
+fi
 
 . "$B2G_DIR/.config"
 if [ $? -ne 0 ]; then

--- a/scripts/marionette.sh
+++ b/scripts/marionette.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Determine the absolute path of our location.
+B2G_DIR=$(cd `dirname $0`/..; pwd)
+. $B2G_DIR/setup.sh
+
+# Use default Gecko location if it's not provided in .config.
+if [ -z $GECKO_PATH ]; then
+  GECKO_PATH=$B2G_DIR/gecko
+fi
+
+# Run standard set of tests by default. Command line arguments can be
+# specified to run specific tests (an individual test file, a directory,
+# or an .ini file).
+TEST_PATH=$GECKO_PATH/testing/marionette/client/marionette/tests/unit-tests.ini
+MARIONETTE_FLAGS+=" --homedir=$B2G_DIR--type=b2g"
+USE_EMULATOR=yes
+
+# Allow other marionette arguments to override the default --emulator argument
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --address=*|--emulator=*)
+      MARIONETTE_FLAGS+=" $1"
+      USE_EMULATOR=no ;;
+    --*)
+      MARIONETTE_FLAGS+=" $1" ;;
+    *)
+      MARIONETTE_TESTS+=" $1" ;;
+  esac
+  shift
+done
+
+if [ "$USE_EMULATOR" = "yes" ]; then
+  if [ "$DEVICE" = "generic_x86" ]; then
+    ARCH=x86
+  else
+    ARCH=arm
+  fi
+  MARIONETTE_FLAGS+=" --emulator=$ARCH"
+fi
+
+MARIONETTE_TESTS=${MARIONETTE_TESTS:-$TEST_PATH}
+
+echo "Running tests: $MARIONETTE_TESTS"
+
+SCRIPT=$GECKO_PATH/testing/marionette/client/marionette/venv_test.sh
+PYTHON=`which python`
+
+echo bash $SCRIPT "$PYTHON" $MARIONETTE_FLAGS $MARIONETTE_TESTS
+bash $SCRIPT "$PYTHON" $MARIONETTE_FLAGS $MARIONETTE_TESTS

--- a/scripts/mochitest.sh
+++ b/scripts/mochitest.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+B2G_DIR=$(cd `dirname $0`/..; pwd)
+. $B2G_DIR/load-config.sh
+
+# Use default Gecko location if it's not provided in .config.
+if [ -z $GECKO_PATH ]; then
+  GECKO_PATH=$B2G_DIR/gecko
+fi
+
+XRE_PATH=$B2G_DIR/gaia/xulrunner-sdk/bin
+MOCHITEST_FLAGS+="--b2gpath $B2G_DIR --xre-path $XRE_PATH"
+SCRIPT=$GECKO_PATH/testing/marionette/client/marionette/venv_mochitest.sh
+
+PYTHON=`which python`
+
+echo bash $SCRIPT "$PYTHON" $MOCHITEST_FLAGS $@
+GECKO_OBJDIR=$GECKO_OBJDIR \
+  bash $SCRIPT "$PYTHON" $MOCHITEST_FLAGS $@


### PR DESCRIPTION
This change basically makes test.sh a forwarding script for either scripts/marionette.sh or scripts/mochitest.sh. Note that marionette is retained as the default test frontend for test.sh, so it should work like it did before..

Depends on https://bugzilla.mozilla.org/show_bug.cgi?id=797154
