### PR TITLE
Don't assume B2G_HOME is the current folder but take the script location instead

### DIFF
--- a/run-emulator.sh
+++ b/run-emulator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-B2G_HOME=$(cd $(dirname $BASH_SOURCE); pwd)
+B2G_HOME=$(dirname $BASH_SOURCE)
 
 . $B2G_HOME/load-config.sh
 

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-B2G_HOME=$(cd $(dirname $BASH_SOURCE); pwd)
+B2G_HOME=$(dirname $BASH_SOURCE)
 
 usage() {
     echo "Usage: $0 [marionette|mochitest] (frontend-args)"


### PR DESCRIPTION
Right now you can only run the emulator from within the b2g folder. With this change you can start it from whatever the current working directory is. Keep in mind that I have also updated tests.sh because it would fail if there is another wrapper script around it. So BASH_SOURCE is the right way to do it.
