### PR TITLE
split the source tree and device configuration into two scripts

### DIFF
--- a/config-device.sh
+++ b/config-device.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+case `uname` in
+"Darwin")
+	CORE_COUNT=`system_profiler SPHardwareDataType | grep "Cores:" | sed -e 's/[ a-zA-Z:]*\([0-9]*\)/\1/'`
+	;;
+"Linux")
+	CORE_COUNT=`grep processor /proc/cpuinfo | wc -l`
+	;;
+*)
+	echo Unsupported platform: `uname`
+	exit -1
+esac
+
+echo MAKE_FLAGS=-j$((CORE_COUNT + 2)) > .tmp-config
+echo GECKO_OBJDIR=$PWD/objdir-gecko >> .tmp-config
+echo DEVICE_NAME=$1 >> .tmp-config
+
+case "$1" in
+"galaxy-s2")
+	echo DEVICE=galaxys2 >> .tmp-config
+	;;
+
+"galaxy-nexus")
+	echo DEVICE=maguro >> .tmp-config
+	;;
+
+"optimus-l5")
+	echo DEVICE=m4 >> .tmp-config
+	;;
+
+"nexus-s")
+	echo DEVICE=crespo >> .tmp-config
+	;;
+
+"nexus-s-4g")
+	echo DEVICE=crespo4g >> .tmp-config
+	;;
+
+"otoro"|"unagi")
+	echo DEVICE=$1 >> .tmp-config
+	;;
+
+"pandaboard")
+	echo DEVICE=panda >> .tmp-config
+	;;
+
+"emulator")
+	echo DEVICE=generic >> .tmp-config
+	echo LUNCH=full-eng >> .tmp-config
+	;;
+
+"emulator-x86")
+	echo DEVICE=generic_x86 >> .tmp-config
+	echo LUNCH=full_x86-eng >> .tmp-config
+	;;
+
+*)
+	echo Usage: $0 \(device name\)
+	echo
+	echo Valid devices to configure are:
+	echo - galaxy-s2
+	echo - galaxy-nexus
+	echo - nexus-s
+	echo - nexus-s-4g
+	echo - otoro
+	echo - unagi
+	echo - pandaboard
+	echo - emulator
+	echo - emulator-x86
+	exit -1
+	;;
+esac
+
+if [ $? -ne 0 ]; then
+	echo Configuration failed
+	exit -1
+fi
+
+mv .tmp-config .config
+
+echo Run \|./build.sh\| to start building

--- a/config.sh
+++ b/config.sh
@@ -1,32 +1,9 @@
 #!/bin/bash
+# This script understands how to create and sync a B2G source tree.
+# config.sh script used to also configure the .config file and even
+# further back also drove the blob setup
 
 REPO=./repo
-
-repo_sync() {
-	rm -rf .repo/manifest* &&
-	$REPO init -u $GITREPO -b $BRANCH -m $1.xml &&
-	$REPO sync
-	ret=$?
-	if [ "$GITREPO" = "$GIT_TEMP_REPO" ]; then
-		rm -rf $GIT_TEMP_REPO
-	fi
-	if [ $ret -ne 0 ]; then
-		echo Repo sync failed
-		exit -1
-	fi
-}
-
-case `uname` in
-"Darwin")
-	CORE_COUNT=`system_profiler SPHardwareDataType | grep "Cores:" | sed -e 's/[ a-zA-Z:]*\([0-9]*\)/\1/'`
-	;;
-"Linux")
-	CORE_COUNT=`grep processor /proc/cpuinfo | wc -l`
-	;;
-*)
-	echo Unsupported platform: `uname`
-	exit -1
-esac
 
 GITREPO=${GITREPO:-"git://github.com/mozilla-b2g/b2g-manifest"}
 BRANCH=${BRANCH:-master}
@@ -34,7 +11,6 @@ BRANCH=${BRANCH:-master}
 GIT_TEMP_REPO="tmp_manifest_repo"
 if [ -n "$2" ]; then
 	GITREPO=$GIT_TEMP_REPO
-	GITBRANCH="master"
 	rm -rf $GITREPO &&
 	git init $GITREPO &&
 	cp $2 $GITREPO/$1.xml &&
@@ -42,82 +18,30 @@ if [ -n "$2" ]; then
 	git add $1.xml &&
 	git commit -m "manifest" &&
 	cd ..
+
+    if [ $? -ne 0 ] ; then
+        echo Could not set up temporary manifest repository
+        exit -1
+    fi
 fi
 
-echo MAKE_FLAGS=-j$((CORE_COUNT + 2)) > .tmp-config
-echo GECKO_OBJDIR=$PWD/objdir-gecko >> .tmp-config
-echo DEVICE_NAME=$1 >> .tmp-config
-
-case "$1" in
-"galaxy-s2")
-	echo DEVICE=galaxys2 >> .tmp-config &&
-	repo_sync $1
-	;;
-
-"galaxy-nexus")
-	echo DEVICE=maguro >> .tmp-config &&
-	repo_sync $1
-	;;
-
-"optimus-l5")
-	echo DEVICE=m4 >> .tmp-config &&
-	repo_sync $1
-	;;
-
-"nexus-s")
-	echo DEVICE=crespo >> .tmp-config &&
-	repo_sync $1
-	;;
-
-"nexus-s-4g")
-	echo DEVICE=crespo4g >> .tmp-config &&
-	repo_sync $1
-	;;
-
-"otoro"|"unagi")
-	echo DEVICE=$1 >> .tmp-config &&
-	repo_sync $1
-	;;
-
-"pandaboard")
-	echo DEVICE=panda >> .tmp-config &&
-	repo_sync $1
-	;;
-
-"emulator")
-	echo DEVICE=generic >> .tmp-config &&
-	echo LUNCH=full-eng >> .tmp-config &&
-	repo_sync $1
-	;;
-
-"emulator-x86")
-	echo DEVICE=generic_x86 >> .tmp-config &&
-	echo LUNCH=full_x86-eng >> .tmp-config &&
-	repo_sync emulator
-	;;
-
-*)
-	echo Usage: $0 \(device name\)
-	echo
-	echo Valid devices to configure are:
-	echo - galaxy-s2
-	echo - galaxy-nexus
-	echo - nexus-s
-	echo - nexus-s-4g
-	echo - otoro
-	echo - unagi
-	echo - pandaboard
-	echo - emulator
-	echo - emulator-x86
+rm -rf .repo/manifest* &&
+$REPO init -u $GITREPO -b $BRANCH -m $1.xml &&
+$REPO sync
+ret=$?
+if [ "$GITREPO" = "$GIT_TEMP_REPO" ]; then
+	rm -rf $GIT_TEMP_REPO
+fi
+if [ $ret -ne 0 ]; then
+	echo Repo sync failed
 	exit -1
-	;;
-esac
+fi
 
 if [ $? -ne 0 ]; then
-	echo Configuration failed
+	echo Source tree sync failed
 	exit -1
 fi
 
-mv .tmp-config .config
+# Start to actually configure the device
+./config-device.sh $1
 
-echo Run \|./build.sh\| to start building


### PR DESCRIPTION
This change sets us up to make it it easier to make it possible to do a fully repo managed source tree of B2G.

With this change, config.sh becomes a light wrapper on repo which understands how our manifests repository is laid out.  It no longer understands any devices, so the error message for configuring an unknown devices is a little less helpful

<pre>jhford-wifi:~/b2g/b2g-upstream $ ./config.sh unknown
Get git://github.com/mozilla-b2g/b2g-manifest
remote: Counting objects: 347, done.
remote: Compressing objects: 100% (166/166), done.
remote: Total 347 (delta 130), reused 301 (delta 88)
Receiving objects: 100% (347/347), 42.92 KiB, done.
Resolving deltas: 100% (130/130), done.
From git://github.com/mozilla-b2g/b2g-manifest
 * [new branch]      crespo     -> origin/crespo
 * [new branch]      crespo4g   -> origin/crespo4g
 * [new branch]      galaxy-s2  -> origin/galaxy-s2
 * [new branch]      m4         -> origin/m4
 * [new branch]      maguro     -> origin/maguro
 * [new branch]      master     -> origin/master
 * [new branch]      nightly    -> origin/nightly
 * [new branch]      otoro      -> origin/otoro
 * [new branch]      otoro_m4-demo -> origin/otoro_m4-demo
 * [new branch]      panda      -> origin/panda
fatal: manifest 'unknown.xml' not available
fatal: manifest unknown.xml not found
Repo sync failed
</pre>

Creating the .config file for the devices as well as setting other useful variables moves to config-device.sh.  In order to maintain the current user interface, the config.sh script passes a valid value to the config-device.sh script