### PR TITLE
Fetch only current branch without history in order to speedup cloning B2G

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -4,8 +4,8 @@ REPO=./repo
 
 repo_sync() {
 	rm -rf .repo/manifest* &&
-	$REPO init -u $GITREPO -b $BRANCH -m $1.xml &&
-	$REPO sync
+	$REPO init -u $GITREPO -b $BRANCH -m $1.xml --depth 1 &&
+	$REPO sync --current-branch
 	ret=$?
 	if [ "$GITREPO" = "$GIT_TEMP_REPO" ]; then
 		rm -rf $GIT_TEMP_REPO


### PR DESCRIPTION
Without this patch, after `./config.sh` B2G folder is 9.4G.
With it, it is only 6.5G.

It doesn't mean that we avoid downloading 3GB of data as there is some uncompressed data, but I'm pretty sure it will avoid avoid some significant amount of data to be downloaded!!

From what I can see, we can still submit pull request with `git --clone --depth 1 ...`. Some urban legend tells that you can't do anything when using `--depth` option. Having said that, this patch isn't naive and might be painfull for some usecases ?
