### PR TITLE
allow storing gonk upstream changes as patches instead of forks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,7 @@ function configure_device() {
 
 export REPO=$PWD/repo
 export B2G_TREEID_SH="$PWD/patches/treeid.sh"
-export B2G_HASHED_FILES="vendorsetup.sh ${B2G_TREEID_SH}"
+export B2G_HASHED_FILES="$PWD/patches/vendorsetup.sh ${B2G_TREEID_SH}"
 export B2G_PATCH_DIRS_OVERRIDE=patches
 
 . setup.sh &&


### PR DESCRIPTION
This patch imports codeaurora forum code into our repostiory, annotating the revision and remote used to pull it down.  There is a change to the treeid.sh function, which naïvely parses the makefile to figure out which version of Android is in use.  This is done because the default method of testing for ICS/GB checks if the galaxy nexus devices files are present, which they never are for us.  The regular expression doesn't check whether there are multiple un-commented definitions, or whether the definition found is actually the correct definition.  There are no patches included with this patch, adding the gonk-patches repository to the b2g-manifests will be a follow up.
