### PR TITLE
Fix local xml setup when using BRANCH!=master

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -34,13 +34,13 @@ BRANCH=${BRANCH:-nightly}
 GIT_TEMP_REPO="tmp_manifest_repo"
 if [ -n "$2" ]; then
 	GITREPO=$GIT_TEMP_REPO
-	GITBRANCH="master"
 	rm -rf $GITREPO &&
 	git init $GITREPO &&
 	cp $2 $GITREPO/$1.xml &&
 	cd $GITREPO &&
 	git add $1.xml &&
 	git commit -m "manifest" &&
+	git branch -m $BRANCH &&
 	cd ..
 fi
 


### PR DESCRIPTION
This fixes config.sh use with a bare .xml file.  This was broken when we switched B2G's default BRANCH to nightly.
