### PR TITLE
Need to exclude some ./flash.sh commands for pandaboard

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -66,7 +66,9 @@ fastboot_flash_image()
 
 flash_fastboot()
 {
-	run_adb reboot bootloader ;
+	if [ $DEVICE != "panda" ]; then
+		run_adb reboot bootloader ;
+	fi
 	run_fastboot devices &&
 	( [ "$1" = "nounlock" ] || run_fastboot oem unlock || true )
 
@@ -81,14 +83,18 @@ flash_fastboot()
 		;;
 
 	*)
-		run_fastboot erase cache &&
-		run_fastboot erase userdata &&
+		run_fastboot erase cache
+		if [ $DEVICE != "panda" ]; then
+	        	run_fastboot erase userdata
+		fi
 		fastboot_flash_image userdata &&
 		([ ! -e out/target/product/$DEVICE/boot.img ] ||
 		fastboot_flash_image boot) &&
 		fastboot_flash_image system &&
-		run_fastboot reboot &&
-		update_time
+		run_fastboot reboot
+		if [ $DEVICE != "panda" ]; then
+		        update_time
+		fi
 		;;
 	esac
 	echo -ne \\a


### PR DESCRIPTION
Pandaboards are special. You have to manually put the pandaboard in fastboot mode because any 'reboot' command causes it to just shutdown and not reboot, so I had to change some things in ./flash.sh:
- remove reboot bootloader code,
- erase userdata takes eons to complete and isn't necessary, so i removed it
- update_time doesn't work because you can't reboot the panda this way. It just shuts down, so i removed it for pandas

I tested this flash.sh file against a pandaboard and for an unagi build, and it works as expected. The Unagi build runs all the previous commands, and the pandabuild excludes the ones in the if statements.
