### PR TITLE
Unset CDPATH before invoking make

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,7 @@ function configure_device() {
     return $?
 }
 
+unset CDPATH
 . setup.sh &&
 if [ -f patches/patch.sh ] ; then
     . patches/patch.sh


### PR DESCRIPTION
At least one of Android's Makefiles parses the output of `cd' during
the build process. Having a custom CDPATH envvar set changes that
output, which breaks the build. This change simply unsets CDPATH
before calling make.
