### PR TITLE
Changes needed to support per-device patch queues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,16 +52,9 @@ function configure_device() {
     return $?
 }
 
-export REPO=$PWD/repo
-export B2G_TREEID_SH="$PWD/patches/treeid.sh"
-# We include .config in the list of hashed files now because we have
-# per-device patch queues, since it's where we pick the device to build
-export B2G_HASHED_FILES="$PWD/patches/vendorsetup.sh ${B2G_TREEID_SH} $PWD/.config"
-export B2G_PATCH_DIRS_OVERRIDE=patches
-
 . setup.sh &&
-if [ -f patches/vendorsetup.sh ] ; then
-    . patches/vendorsetup.sh
+if [ -f patches/patch.sh ] ; then
+    . patches/patch.sh
 fi &&
 configure_device &&
 time nice -n19 make $MAKE_FLAGS $@


### PR DESCRIPTION
In order to have per-device patch queues, as requested in bug 832002, we need to have the patching script know to re-patch the tree when we change devices.  Instead of doing something flakey in config.sh, let's just include the .config file (which has the device specified) in the list of files that the patching infrastructure cares about whether or not it's changed.

This is a trivial change.  I'm happy to land without the comment if it's felt to be unnecessary.
