### PR TITLE
Fix path checking for old Xcode.

### DIFF
--- a/scripts/bootstrap-mac.sh
+++ b/scripts/bootstrap-mac.sh
@@ -269,7 +269,7 @@ check_xcode() {
     
     # Assume the old Xcode 3 location, then look elsewhere
     
-    if [ -d "/Developer" ]; then
+    if [ -d "/Developer/Applications/Xcode.app" ]; then
       xcode_path=/Developer/Applications/Xcode.app
       osx_106_sdk=/Developer/SDKs/MacOSX10.6.sdk
       osx_sdk=$osx_106_sdk


### PR DESCRIPTION
When the tool installed under /Developer (like Nvidia Cg toolkit) exists, $xcode_path is not set correctly. 
