### PR TITLE
profile-symbolicate.py should only search for files

### DIFF
--- a/scripts/profile-symbolicate.py
+++ b/scripts/profile-symbolicate.py
@@ -93,7 +93,7 @@ class Library:
     args = ["find", dir]
     if exclude_dir:
       args = args + ["!", "(", "-name", exclude_dir, "-prune", ")"]
-    args = args + ["-name", basename, "-print", "-quit"]
+    args = args + ["-name", basename, "-type", "f", "-print", "-quit"]
     fullname = subprocess.check_output(args)
     if len(fullname) > 0:
       if fullname[-1] == "\n":


### PR DESCRIPTION
profile-symbolicate.py needs to use '-type f' to limit the search to files; it can find the "b2g" directory for the "b2g" binary when stackwalking is enabled and blow up.
