### PR TITLE
Make generate-orangutan-script.py use a seed.

### DIFF
--- a/scripts/generate-orangutan-script.py
+++ b/scripts/generate-orangutan-script.py
@@ -7,6 +7,11 @@ def main():
   parser.add_argument("-s", "--steps", help="Number of steps")
   args = parser.parse_args(sys.argv[1:])
 
+  rndSeed = random()
+  fuzzSeed = str(rndSeed)  # replace rndSeed here with the required seed
+  #print 'Current seed is: ' + fuzzSeed
+  rnd = Random(fuzzSeed)
+
   maxX = 320
   # The home key is around (44, 515) on unagi.
   # Filed a followup bug (838267) for better key support.
@@ -26,21 +31,21 @@ def main():
       sleepAllowed = 1
       continue
 
-    x = choice(['tap', 'sleep', 'drag'])
+    x = rnd.choice(['tap', 'sleep', 'drag'])
     if x == 'tap':
       # tap [x] [y] [num times] [duration of each tap in msec]
-      print 'tap ', randint(1, maxX), ' ', randint(1, maxY), ' ', randint(1,3), randint(50, 1000)
+      print 'tap ', rnd.randint(1, maxX), ' ', rnd.randint(1, maxY), ' ', rnd.randint(1,3), rnd.randint(50, 1000)
       sleepAllowed = 1
       count = count + 1
     elif x == 'sleep':
       # sleep [duration in msec]
       if (sleepAllowed):
-        print 'sleep', randint(100, 3000)
+        print 'sleep', rnd.randint(100, 3000)
         count = count + 1
         sleepAllowed = 0
     else:
       # drag [start x] [start y] [end x] [end y] [num steps] [duration in msec]
-      print 'drag',randint(1, maxX), ' ', randint(1, maxY), ' ' , randint(1, maxX), ' ', randint(1, maxY), ' ', randint(10, 20), ' ', randint(10, 350)
+      print 'drag',rnd.randint(1, maxX), ' ', rnd.randint(1, maxY), ' ' , rnd.randint(1, maxX), ' ', rnd.randint(1, maxY), ' ', rnd.randint(10, 20), ' ', rnd.randint(10, 350)
       sleepAllowed = 1
       count = count + 1
 


### PR DESCRIPTION
Here's a proposed patch to make generate-orangutan-script.py use a seed. Originally I wanted it to print the seed but it might break the generated script so I commented out the print line.
