### PR TITLE
Bug 845049 - tell emulator to use the real camera

### DIFF
--- a/run-emulator.sh
+++ b/run-emulator.sh
@@ -48,4 +48,5 @@ ${DBG_CMD} $EMULATOR \
    -skin HVGA \
    -verbose \
    -gpu on \
+   -camera-back webcam0 \
    -qemu $TAIL_ARGS


### PR DESCRIPTION
Add the |-camera-back webcam0| parameter to run-emulator.sh, to allow it to access a real camera.
