### PR TITLE
Fix ARM return addresses so that they addr2line correctly.

### DIFF
--- a/scripts/profile-symbolicate.py
+++ b/scripts/profile-symbolicate.py
@@ -56,7 +56,10 @@ class Library:
       lib_address = int(address_str, 0) - self.start + self.offset
       if self.verbose:
         print "Address %s maps to library '%s' offset 0x%08x" % (address_str, self.host_name, lib_address)
-      args.append("0x%08x" % lib_address)
+      # Fix up addresses from stack frames; they're for the insn after
+      # the call, which might be different function thanks to inlining:
+      adj_address = (lib_address & ~1) - 1
+      args.append("0x%08x" % adj_address)
     # Calling addr2line will return 2 lines for each address. The output will be something
     # like the following:
     #   PR_IntervalNow


### PR DESCRIPTION
The addresses we'll get from NS_StackWalk on ARM will be the saved LR
values, which are for the instruction after the call (with the low bit
set if Thumb).  Because we use addr2line and report the innermost of
the stack of inlined functions at the point in question (if any), this
can result in showing a confusingly unrelated function.  (Note that it
could also fail in general, if the function ends with a call as result
of noreturn annotation.)

This change uses the address of the last byte in the call instruction,
rather than the start of the instruction, which is generally the correct
way to indicate being in the middle of a call for debug information,
although the difference shouldn't matter for addr2line.

However, it offsets _all_ the samples, which isn't quite right; a saved
PC from a fault should be used as-is. It's also not clear if this should
happen here or earlier in the pipeline.
