### PR TITLE
Load device specific configuration

### DIFF
--- a/load-config.sh
+++ b/load-config.sh
@@ -10,6 +10,12 @@ if [ $? -ne 0 ]; then
 	exit -1
 fi
 
+for config in device/*/$DEVICE/config; do
+	if [ -f $config ] ; then
+		. $config
+	fi
+done
+
 if [ -f "$B2G_DIR/.userconfig" ]; then
 	. "$B2G_DIR/.userconfig"
 fi


### PR DESCRIPTION
If 'config' file exists in device path, load it.

Signed-off-by: Hiroyuki Ikezoe hiikezoe@gnome.org
