### PR TITLE
Enable prelink on otoro, unagi, keon, inari, leo, hamachi by default.

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -76,6 +76,7 @@ case "$1" in
 
 "otoro"|"unagi"|"keon"|"inari"|"leo"|"hamachi")
 	echo DEVICE=$1 >> .tmp-config &&
+	echo ENABLE_GLOBAL_PRELINK=1 >> .tmp-config &&
 	repo_sync $1
 	;;
 

--- a/setup.sh
+++ b/setup.sh
@@ -16,5 +16,6 @@ export B2G_NOOPT &&
 export B2G_DEBUG &&
 export MOZ_CHROME_MULTILOCALE &&
 export L10NBASEDIR &&
+export ENABLE_GLOBAL_PRELINK &&
 . build/envsetup.sh &&
 lunch $LUNCH


### PR DESCRIPTION
DEPENDS ON:
https://github.com/mozilla-b2g/platform_external_apriori/pull/2
https://github.com/mozilla-b2g/gonk-misc/pull/81
