### PR TITLE
 Add Peak to printed list of supported devices 

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -114,6 +114,7 @@ case "$1" in
 	echo - unagi
 	echo - inari
 	echo - keon
+	echo - peak
 	echo - leo
 	echo - hamachi
 	echo - tara


### PR DESCRIPTION
Geeksphone Peak was supported but not listed when doing `./config.sh -h`.
