### PR TITLE
Bug 831147: Add cmake to Mac bootstrap script.

### DIFF
--- a/scripts/bootstrap-mac.sh
+++ b/scripts/bootstrap-mac.sh
@@ -119,6 +119,13 @@ bootstrap_mac() {
         echo "Found yasm: $yasm"
     fi
 
+    cmake=`which cmake`
+    if [ $? -ne 0 ]; then
+        homebrew_formulas+=" cmake:cmake"
+    else
+        echo "Found cmake: $cmake"
+    fi
+
     found_autoconf213=1
     autoconf213=`which autoconf213`
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
The addition of apitrace introduces a new dependency on cmake.  Make sure
this is properly installed in the bootstrap script.  The wiki will need to
be updated separately.
