### PR TITLE
Bug 874379: push prebuilt ARM busybox on ARM emulator only

### DIFF
--- a/scripts/xpcshell.sh
+++ b/scripts/xpcshell.sh
@@ -8,13 +8,12 @@ if [ -z $GECKO_PATH ]; then
   GECKO_PATH=$B2G_DIR/gecko
 fi
 
-BUSYBOX=$B2G_DIR/gaia/build/busybox-armv6l
+BUSYBOX_ARM=$B2G_DIR/gaia/build/busybox-armv6l
 TEST_PACKAGE_STAGE_DIR=$GECKO_OBJDIR/dist/test-package-stage
 TESTING_MODULES_DIR=$TEST_PACKAGE_STAGE_DIR/modules
 
 XPCSHELL_FLAGS+=" --b2gpath $B2G_DIR \
                   --use-device-libs \
-                  --busybox $BUSYBOX \
                   --testing-modules-dir $TESTING_MODULES_DIR"
 
 OUT_HOST=$B2G_DIR/out/host/`uname -s | tr "[[:upper:]]" "[[:lower:]]"`-x86
@@ -22,7 +21,8 @@ ADB=${ADB:-$OUT_HOST/bin/adb}
 XPCSHELL_FLAGS+=" --adbpath $ADB"
 
 if [ "$DEVICE" = "generic" ]; then
-  XPCSHELL_FLAGS+=" --emulator arm"
+  XPCSHELL_FLAGS+=" --emulator arm \
+                    --busybox $BUSYBOX_ARM"
 elif [ "$DEVICE" = "generic_x86" ]; then
   XPCSHELL_FLAGS+=" --emulator x86"
 fi


### PR DESCRIPTION
The prebuilt busybox executable is only for ARM.  Pushing such executable to emulator-x86 is meaningless and causes unexpected errors in python scripts.
