### PR TITLE
Let config.sh take common |repo sync| options and pass them through.

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 REPO=${REPO:-./repo}
+sync_flags=""
 
 repo_sync() {
 	rm -rf .repo/manifest* &&
 	$REPO init -u $GITREPO -b $BRANCH -m $1.xml &&
-	$REPO sync
+	$REPO sync $sync_flags
 	ret=$?
 	if [ "$GITREPO" = "$GIT_TEMP_REPO" ]; then
 		rm -rf $GIT_TEMP_REPO
@@ -30,6 +31,26 @@ esac
 
 GITREPO=${GITREPO:-"git://github.com/mozilla-b2g/b2g-manifest"}
 BRANCH=${BRANCH:-v1-train}
+
+while [ $# -ge 1 ]; do
+	case $1 in
+	-d|-l|-f|-n|-c|-q)
+		sync_flags="$sync_flags $1"
+		shift
+		;;
+	--help|-h)
+		# The main case statement will give a usage message.
+		break
+		;;
+	-*)
+		echo "$0: unrecognized option $1" >&2
+		exit 1
+		;;
+	*)
+		break
+		;;
+	esac
+done
 
 GIT_TEMP_REPO="tmp_manifest_repo"
 if [ -n "$2" ]; then
@@ -103,7 +124,8 @@ case "$1" in
 	;;
 
 *)
-	echo Usage: $0 \(device name\)
+	echo "Usage: $0 [-cdflnq] (device name)"
+	echo "Flags are passed through to |./repo sync|."
 	echo
 	echo Valid devices to configure are:
 	echo - galaxy-s2


### PR DESCRIPTION
For example, -d (check out the manifest revisions, instead of trying to
rebase the current HEADs onto them) is useful when changing branches or
devices, to prevent unwanted rebases that often fail.
