### PR TITLE
Fix report deletion

### DIFF
--- a/tools/include/device_utils.py
+++ b/tools/include/device_utils.py
@@ -322,5 +322,5 @@ def _remove_files_from_device(outfiles_prefixes, old_files):
     '''
     files_to_remove = _list_remote_temp_files(outfiles_prefixes) - old_files
 
-    # Hopefully this command line won't get too long for ADB.
-    remote_toolbox_cmd('rm', ' '.join([str(f) for f in files_to_remove]))
+    for f in files_to_remove:
+        remote_toolbox_cmd('rm', f)


### PR DESCRIPTION
Get_about_memory.py was failing to remove memory report files when there were a large number of files. Found when using get_about_memory.py with the b2g emulator (thanks JLebar for telling me the fix in Bug 897627.
