### PR TITLE
Bug 891217 (follow-up): repo sync correct target for emulator-x86-jb

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -126,7 +126,7 @@ case "$1" in
 "emulator-x86"|"emulator-x86-jb")
 	echo DEVICE=generic_x86 >> .tmp-config &&
 	echo LUNCH=full_x86-eng >> .tmp-config &&
-	repo_sync emulator
+	repo_sync $1
 	;;
 
 *)


### PR DESCRIPTION
Should repo sync correct target for "emulator-x86-jb", or it will become "emulator".
