### PR TITLE
Bug 906316 - Append 'xulrunner-sdk' to XRE Path

### DIFF
--- a/tools/mach_b2g_bootstrap.py
+++ b/tools/mach_b2g_bootstrap.py
@@ -107,7 +107,7 @@ def _find_xulrunner_sdk(gaia_dir):
     sdk = sorted(xulrunner_sdks,
                  key=lambda x: int(x[len(x.rstrip('0123456789')):] or 0),
                  reverse=True)[0]
-    return os.path.join(gaia_dir, sdk)
+    return os.path.join(gaia_dir, sdk, 'xulrunner-sdk')
 
 def bootstrap(b2g_home):
     # Ensure we are running Python 2.7+. We put this check here so we generate a


### PR DESCRIPTION
With bug 906316 we are now able to have multiple versions of the SDKs on
disk, to avoid always re-downloading them. Path has changed, and we need
to append 'xulrunner-sdk' so that the binary can be used.
