### PR TITLE
Bug 942219 - Wrong homebrew url in bootstrap-mac.sh

### DIFF
--- a/scripts/bootstrap-mac.sh
+++ b/scripts/bootstrap-mac.sh
@@ -434,7 +434,7 @@ install_homebrew() {
         )
     fi
 
-    installer_url="https://raw.github.com/mxcl/homebrew/go"
+    installer_url="https://raw.github.com/mxcl/homebrew/go/install"
 
     run_command curl -fsSL $installer_url -o $tmp_installer
     run_command ruby $tmp_installer


### PR DESCRIPTION
See Bug 942219 - Wrong homebrew url in bootstrap-mac.sh:

The bootstrap script for mac points to:
        https://raw.github.com/mxcl/homebrew/go
for auto-downloading homebrew.

This should be here:
        https://raw.github.com/mxcl/homebrew/go/install

This commit corrects the url.
