### PR TITLE
bug 965803 -- add repo init and sync flags

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -5,8 +5,8 @@ sync_flags=""
 
 repo_sync() {
 	rm -rf .repo/manifest* &&
-	$REPO init -u $GITREPO -b $BRANCH -m $1.xml &&
-	$REPO sync $sync_flags
+	$REPO init -u $GITREPO -b $BRANCH -m $1.xml $REPO_INIT_FLAGS &&
+	$REPO sync $sync_flags $REPO_SYNC_FLAGS
 	ret=$?
 	if [ "$GITREPO" = "$GIT_TEMP_REPO" ]; then
 		rm -rf $GIT_TEMP_REPO


### PR DESCRIPTION
I verified that this does work:

<pre>
$ REPO_INIT_FLAGS='-q --no-repo-verify' ./config.sh emulator-jb
....
+ ./repo init -u git://github.com/mozilla-b2g/b2g-manifest -b master -m emulator-jb.xml -q --no-repo-verify
</pre>
