### PR TITLE
Bug 951565: Set GECKO_PATH if not defined by config

### DIFF
--- a/load-config.sh
+++ b/load-config.sh
@@ -13,3 +13,8 @@ fi
 if [ -f "$B2G_DIR/.userconfig" ]; then
 	. "$B2G_DIR/.userconfig"
 fi
+
+# Use default Gecko location if it's not provided in config files.
+if [ -z $GECKO_PATH ]; then
+  GECKO_PATH=$B2G_DIR/gecko
+fi

--- a/scripts/updates.sh
+++ b/scripts/updates.sh
@@ -4,11 +4,6 @@
 B2G_DIR=$(cd `dirname $0`/..; pwd)
 . $B2G_DIR/setup.sh
 
-# Use default Gecko location if it's not provided in .config.
-if [ -z $GECKO_PATH ]; then
-  GECKO_PATH=$B2G_DIR/gecko
-fi
-
 # Run standard set of tests by default. Command line arguments can be
 # specified to run specific tests (an individual test file, a directory,
 # or an .ini file).

--- a/scripts/xpcshell.sh
+++ b/scripts/xpcshell.sh
@@ -3,11 +3,6 @@
 B2G_DIR=$(cd `dirname $0`/..; pwd)
 . $B2G_DIR/load-config.sh
 
-# Use default Gecko location if it's not provided in .config.
-if [ -z $GECKO_PATH ]; then
-  GECKO_PATH=$B2G_DIR/gecko
-fi
-
 VIRTUAL_ENV_VERSION="49f40128a9ca3824ebf253eca408596e135cf893"
 BUSYBOX=$B2G_DIR/gaia/build/busybox-armv6l
 TEST_PACKAGE_STAGE_DIR=$GECKO_OBJDIR/dist/test-package-stage


### PR DESCRIPTION
The load-config script sets GECKO_PATH if it's not defined in a
config file. Similar code in other scripts has been cleaned up.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
