### PR TITLE
Bug 946407: Accept a single unified-memory-report file. r=njn

### DIFF
--- a/tools/get_about_memory.py
+++ b/tools/get_about_memory.py
@@ -163,7 +163,9 @@ def get_dumps(args):
             out_dir=out_dir,
             optional_outfiles_prefixes=['dmd-'])
 
-        memory_report_files = [f for f in new_files if f.startswith('memory-report-')]
+        memory_report_files = [f for f in new_files
+                               if f.startswith('memory-report-') or
+                                  f.startswith('unified-memory-report-')]
         dmd_files = [f for f in new_files if f.startswith('dmd-')]
         merged_reports_path = merge_files(out_dir, memory_report_files)
         utils.pull_procrank_etc(out_dir)


### PR DESCRIPTION
Using nsIMemoryReporterManager::GetReports to get memory reports from
content processes means that we have a single collection of report
entries instead of one per process, which means a single file.  But this
code has to deal with geckos both before and after that patch.  So,
this change accepts either N individual "memory-report-_" files or one
"unified-memory-report-_" file (and applies this more generally, because
that was easier than making it specific to the main memory report).
