### PR TITLE
Modify so that get_about_memory.py can hook to other program

### DIFF
--- a/tools/get_about_memory.py
+++ b/tools/get_about_memory.py
@@ -232,7 +232,7 @@ def get_and_show_info(args):
 
     process_dmd_files(dmd_files, args)
 
-if __name__ == '__main__':
+def main():
     parser = argparse.ArgumentParser(description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
@@ -289,3 +289,6 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     get_and_show_info(args)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
It's just a minor change for MTBF driver to hook in get_about_memory.py. Nothing special. It is r+ by Kyle in https://bugzilla.mozilla.org/show_bug.cgi?id=988707. I hope this patch can be in soon. Thanks a lot.
