### PR TITLE
Bug 994985 - All Tarako builds are userdebug, not user or eng. r=mwu

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -135,7 +135,7 @@ case "$1" in
 
 "tarako")
 	echo DEVICE=sp6821a_gonk >> .tmp-config &&
-	echo LUNCH=sp6821a_gonk-userdebug >> .tmp-config &&
+	echo PRODUCT_NAME=sp6821a_gonk >> .tmp-config &&
 	repo_sync $1
 	;;
 


### PR DESCRIPTION
Hi mwu,
Please have a review for the patch. The patch assign PRODUCT_NAME instead of LUNCH on tarako. After that, developer can switch user, user-debug or eng by assigning LUNCH in .userconfig.
