### PR TITLE
Disallow setting BRANCH when using local manifest

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -30,6 +30,14 @@ case `uname` in
 	exit -1
 esac
 
+if [ -n "$BRANCH" ] ; then
+  if [ -n "$2" ] ; then
+    echo "Setting BRANCH and using a local manifest is both confusing" 1>&2
+    echo "and ineffective.  This is almost certainly not what you want" 1>&2
+    exit 1
+  fi
+fi
+
 GITREPO=${GITREPO:-"git://github.com/mozilla-b2g/b2g-manifest"}
 BRANCH=${BRANCH:-master}
 


### PR DESCRIPTION
Using BRANCH figures out which b2g-manifest repository branch to use.  When someone uses a local manifest file instead, we ignore the branch of b2g-manifest.  This can make people think they're getting a certain firefoxos version when they're getting something completely different.