### PR TITLE
Bug 1004868 -  Clean up message printing in tools/get_about_memory.py

### DIFF
--- a/tools/fix_b2g_stack.py
+++ b/tools/fix_b2g_stack.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-'''Prettifies stacks retrieved from a B2G device.
+"""Prettifies stacks retrieved from a B2G device.
 
 This program takes as input a stream or a file containing stack frames
 formatted like
@@ -18,14 +18,14 @@ line.
 This is an analog to fix-linux-stack.pl and is functionally similar to
 $B2G_ROOT/scripts/profile-symbolicate.py.
 
-'''
+"""
 
 from __future__ import print_function
 
 import sys
-if sys.version_info < (2,7):
+if sys.version_info < (2, 7):
     # We need Python 2.7 because we import argparse.
-    print('This script requires Python 2.7.')
+    print('This script requires Python 2.7.', file=sys.stderr)
     sys.exit(1)
 
 import os
@@ -36,33 +36,33 @@ import argparse
 import platform
 import textwrap
 import threading
-import hashlib
-import copy
 import cPickle as pickle
 import fcntl
-from os.path import dirname, basename
+from os.path import dirname
 from collections import defaultdict
 from gzip import GzipFile
 
-def first(pred, iter):
-    '''Return the first element of iter which matches the predicate pred, or
+
+def first(pred, itr):
+    """Return the first element of itr which matches the predicate pred, or
     return None if no such element exists.
 
     This function avoids running pred unnecessarily, so is suitable for use
     when pred is expensive.
 
-    '''
+    """
     try:
-        return itertools.ifilter(pred, iter).next()
+        return itertools.ifilter(pred, itr).next()
     except StopIteration:
         return None
 
+
 def pump(dst, src):
-    '''Pump the file dst into the file src.  When src hits EOF, close dst.
+    """Pump the file dst into the file src.  When src hits EOF, close dst.
 
     Returns a thread object, so you can e.g. join() on the result.
 
-    '''
+    """
     class Pumper(threading.Thread):
         def run(self):
             while True:
@@ -75,14 +75,17 @@ def pump(dst, src):
     p.start()
     return p
 
+
 def _none_factory():
     return None
+
 
 def _defaultdict_none_factory():
     return defaultdict(_none_factory)
 
+
 class FixB2GStacksOptions(object):
-    '''Encapsulates arguments used in fix_b2g_stacks_in_file.
+    """Encapsulates arguments used in fix_b2g_stacks_in_file.
 
     The args argument to __init__() specifies options passed to
     fix_b2g_stacks_in_file.
@@ -121,7 +124,7 @@ class FixB2GStacksOptions(object):
         program.  For example, cross_bin('nm') returns a path to the
         cross-toolchain's nm binary.
 
-    '''
+    """
     def __init__(self, args):
         def get_arg(arg, default=None):
             try:
@@ -147,10 +150,10 @@ class FixB2GStacksOptions(object):
         self.toolchain_dir = get_arg('toolchain_dir', self._guess_toolchain_dir)
         self.remove_cache = get_arg('remove_cache', False)
 
-        self.gecko_objdir = get_arg('gecko_objdir',
-            os.path.join(dirname(__file__), '../objdir-gecko'))
-        self.gonk_objdir = get_arg('gonk_objdir',
-            os.path.join(dirname(__file__), '../out'))
+        self.gecko_objdir = get_arg(
+            'gecko_objdir', os.path.join(dirname(__file__), '../objdir-gecko'))
+        self.gonk_objdir = get_arg(
+            'gonk_objdir', os.path.join(dirname(__file__), '../out'))
 
         product = get_arg('product')
         if product:
@@ -163,7 +166,8 @@ class FixB2GStacksOptions(object):
     def cross_bin(self, bin_name):
         return os.path.join(self.toolchain_dir, self.toolchain_prefix + bin_name)
 
-    def _guess_toolchain_dir(self):
+    @staticmethod
+    def _guess_toolchain_dir():
         patterns = [
             'prebuilt/%(host)s/toolchain/%(target)s-4.4.x',
             'prebuilts/gcc/%(host)s/%(target_arch)s/%(target)s-4.7',
@@ -180,7 +184,8 @@ class FixB2GStacksOptions(object):
                 return maybe_dir
         raise Exception("No toolchain directory found")
 
-    def _guess_gonk_product(self, gonk_objdir):
+    @staticmethod
+    def _guess_gonk_product(gonk_objdir):
         products_dir = os.path.join(gonk_objdir, 'target/product')
         products = os.listdir(products_dir)
         if not products:
@@ -189,14 +194,15 @@ class FixB2GStacksOptions(object):
         if len(products) == 1:
             return os.path.join(products_dir, products[0])
 
-        raise Exception(textwrap.dedent('''
-            Couldn't auto-detect a product because %s has multiple entries.
+        raise Exception(textwrap.dedent(
+            '''Couldn't auto-detect a product because %s has multiple entries.
 
             Please re-run with --product.  Your options are %s.''' %
             (products_dir, products)))
 
+
 class StackFixerCache():
-    '''A cache for StackFixer which occasionally serializes itself to disk.
+    """A cache for StackFixer which occasionally serializes itself to disk.
 
     This cache stores (lib, offset) --> string mappings, so we can avoid
     calling addr2line.  After every so many puts, we write the cache out to
@@ -215,7 +221,7 @@ class StackFixerCache():
     give up.) But note that I have not tested that this locking works as
     intended.
 
-    '''
+    """
     def __init__(self, options):
         self._initialized = False
         self._lib_lookups = None
@@ -240,10 +246,11 @@ class StackFixerCache():
 
     @staticmethod
     def cache_filename():
-        '''Get the filename of our cache.'''
+        """Get the filename of our cache."""
         return os.path.join(dirname(__file__), '.fix_b2g_stack.cache')
 
-    def _read_cache_from_disk(self):
+    @staticmethod
+    def _read_cache_from_disk():
         try:
             with open(StackFixerCache.cache_filename(), 'rb') as cache_file:
                 try:
@@ -292,7 +299,8 @@ class StackFixerCache():
                 except KeyError:
                     pass
 
-    def _get_lib_metadata(self, lib_path):
+    @staticmethod
+    def _get_lib_metadata(lib_path):
         try:
             st = os.stat(lib_path)
             return (os.path.normpath(os.path.abspath(lib_path)),
@@ -321,12 +329,12 @@ class StackFixerCache():
             self._put_counter = 0
 
     def get_maybe_set(self, lib_path, offset, result):
-        '''Get the addr2line result for (lib_path, offset).
+        """Get the addr2line result for (lib_path, offset).
 
         If (lib_path, offset) is not in our cache, insert |result()| or
         |result|, depending on whether |result| is callable.
 
-        '''
+        """
         self._ensure_initialized()
         if not self._lib_lookups[lib_path][offset]:
             if callable(result):
@@ -335,8 +343,9 @@ class StackFixerCache():
                 self.put(lib_path, offset, result)
         return self._lib_lookups[lib_path][offset]
 
+
 class StackFixer(object):
-    '''An object used for translating (lib, offset) tuples into function+file
+    """An object used for translating (lib, offset) tuples into function+file
     names, using addr2line and a cache.
 
     Here and elsewhere we adopt the convention that |lib| is a library's
@@ -347,7 +356,7 @@ class StackFixer(object):
     gives us a chance to flush the cache to disk, making future invocations
     faster.
 
-    '''
+    """
 
     _addr2line_procs = {}
 
@@ -357,13 +366,13 @@ class StackFixer(object):
         self._options = options
 
     def translate(self, lib, offset, pc=None, fn_guess=None):
-        '''Translate the given offset (an integer) into the given library (e.g.
+        """Translate the given offset (an integer) into the given library (e.g.
         'libxul.so') into a human-readable string and return that string.
 
         pc and fn_guess are hints to make the output look nicer; we don't use
         either of these optional parameters to look up lib+offsets.
 
-        '''
+        """
         lib_path = self._find_lib(lib)
         return self._cache.get_maybe_set(lib_path, offset,
             lambda: self._addr2line(lib, offset, pc, fn_guess))
@@ -372,11 +381,11 @@ class StackFixer(object):
         self._cache.flush()
 
     def _init_lib_path_cache(self):
-        '''Initialize self._lib_path_cache by walking all of the subdirectories
+        """Initialize self._lib_path_cache by walking all of the subdirectories
         of self._options.lib_search_dirs and finding all the '*.so', 'b2g', and
         'plugin-container' files therein.
 
-        '''
+        """
         for root, _, files in itertools.chain(*[os.walk(dir) for dir in
                                                 self._options.lib_search_dirs]):
             for f in files:
@@ -384,14 +393,14 @@ class StackFixer(object):
                     self._lib_path_cache[f].append(os.path.join(root, f))
 
     def _find_lib(self, lib):
-        '''Get a path to the given lib (e.g. 'libxul.so').
+        """Get a path to the given lib (e.g. 'libxul.so').
 
         We prefer unstripped versions of the lib, but if all we can find is a
         stripped version, we'll return that.
 
         If we can't find the lib, we return None.
 
-        '''
+        """
         if not self._lib_path_cache:
             self._init_lib_path_cache()
 
@@ -408,12 +417,12 @@ class StackFixer(object):
         return lib_path
 
     def _lib_has_symbols(self, lib_path):
-        '''Check if the given lib_path has symbols.
+        """Check if the given lib_path has symbols.
 
         We do this by running nm on the library.  If it's stripped, nm will not
         output anything to stdout.
 
-        '''
+        """
         proc = subprocess.Popen(
             [self._options.cross_bin('nm'), lib_path],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -425,7 +434,7 @@ class StackFixer(object):
             proc.kill()
 
     def _addr2line(self, lib, offset, pc, fn_guess):
-        '''Use addr2line to translate the given lib+offset.
+        """Use addr2line to translate the given lib+offset.
 
         We use pc only for aesthetic purposes; it's not passed to addr2line or
         anything.
@@ -435,10 +444,11 @@ class StackFixer(object):
         able to resolve function names that addr2line can't.)  fn_guess should
         be this guess, if you have one.
 
-        '''
+        """
         def addr_str():
             _pc = ('0x%x ' % pc) if pc != None else ''
             return '(%s%s+0x%x)' % (_pc, lib, offset)
+
         def fallback_str():
             _fn_guess = fn_guess + ' ' if fn_guess and fn_guess != '???' else ''
             return '%s%s' % (_fn_guess, addr_str())
@@ -460,19 +470,20 @@ class StackFixer(object):
             # first line is of the form "foo()", and the second line is of the
             # form "foo.cpp:123".
             func = proc.stdout.readline().strip()
-            file = os.path.normpath(proc.stdout.readline().strip())
-            if func == '??' and file == '??:0':
+            file_name = os.path.normpath(proc.stdout.readline().strip())
+            if func == '??' and file_name == '??:0':
                 # addr2line wasn't helpful here.
                 return '%s (no addr2line)' % fallback_str()
-            return '%s %s %s' % (func, file, addr_str())
+            return '%s %s %s' % (func, file_name, addr_str())
         except IOError as e:
             # If our addr2line process dies, don't try to restart it.  Just
             # leave it in a dead state and presumably every time we read/write
             # to/from it, we'll hit this case.
             return '%s (addr2line exception)' % fallback_str()
 
+
 def fix_b2g_stacks_in_file(infile, outfile, args={}, **kwargs):
-    '''Read lines from infile and output those lines to outfile with their
+    """Read lines from infile and output those lines to outfile with their
     stack frames rewritten.
 
     infile and outfile may be a files or file-like objects.  For example, to
@@ -482,7 +493,7 @@ def fix_b2g_stacks_in_file(infile, outfile, args={}, **kwargs):
     both).  See the docs on FixB2GStacksOptions for the supported argument
     names.
 
-    '''
+    """
     if args and kwargs:
         raise Exception("Can't pass args and kwargs to fix_b2g_stacks_in_file.")
     options = FixB2GStacksOptions(args if args else kwargs)
@@ -490,7 +501,7 @@ def fix_b2g_stacks_in_file(infile, outfile, args={}, **kwargs):
     if options.remove_cache:
         try:
             os.remove(StackFixerCache.cache_filename())
-        except:
+        except Exception:
             pass
 
     matcher = re.compile(
@@ -506,6 +517,7 @@ def fix_b2g_stacks_in_file(infile, outfile, args={}, **kwargs):
         re.VERBOSE)
 
     fixer = StackFixer(options)
+
     def subfn(match):
         return fixer.translate(match.group('lib'),
                                int(match.group('offset'), 16),
@@ -530,8 +542,9 @@ def fix_b2g_stacks_in_file(infile, outfile, args={}, **kwargs):
     p.join()
     fixer.close()
 
+
 def add_argparse_arguments(parser):
-    '''Add arguments to an argparse parser which make the parser's result
+    """Add arguments to an argparse parser which make the parser's result
     suitable for passing to fix_b2g_stacks_in_file.
 
     You might use this in your code as something like:
@@ -540,7 +553,7 @@ def add_argparse_arguments(parser):
       b2g_stack_group = parser.add_argument_group(...)
       fix_b2g_stack.add_argparse_arguments(b2g_stack_group)
 
-    '''
+    """
     parser.add_argument('--toolchain-dir', metavar='DIR',
                         help='Directory containing toolchain binaries')
     parser.add_argument('--toolchain-prefix', metavar='PREFIX',
@@ -556,7 +569,8 @@ def add_argparse_arguments(parser):
                         help="Delete the persistent addr2line cache before running.")
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description=__doc__,
+    parser = argparse.ArgumentParser(
+        description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('infile', metavar='INFILE', nargs='?',
                         help='File to read from (default: stdin).  gz files are OK.')

--- a/tools/get_about_memory.py
+++ b/tools/get_about_memory.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-'''Get a dump of about:memory from all the processes running on your device.
+"""Get a dump of about:memory from all the processes running on your device.
 
 You can then view these dumps using a recent Firefox nightly on your desktop by
 opening about:memory and using the button at the bottom of the page to load the
@@ -12,15 +12,14 @@ a while, and these logs are large, so you can turn it off if you like.
 This script also saves the output of b2g-procrank and a few other diagnostic
 programs.  If you compiled with DMD and have it enabled, we'll also pull the
 DMD reports.
-
-'''
+"""
 
 from __future__ import print_function
 
 import sys
-if sys.version_info < (2,7):
+if sys.version_info < (2, 7):
     # We need Python 2.7 because we import argparse.
-    print('This script requires Python 2.7.')
+    print('This script requires Python 2.7.', file=sys.stderr)
     sys.exit(1)
 
 import os
@@ -37,8 +36,9 @@ from gzip import GzipFile
 import include.device_utils as utils
 import fix_b2g_stack
 
+
 def process_dmd_files(dmd_files, args):
-    '''Run fix_b2g_stack.py on each of these files.'''
+    """Run fix_b2g_stack.py on each of these files."""
     if not dmd_files or args.no_dmd:
         return
 
@@ -54,7 +54,7 @@ def process_dmd_files(dmd_files, args):
             An error occurred while processing the DMD dumps.  Not to worry!
             The raw dumps are still there; just run fix_b2g_stack.py on
             them.
-            '''))
+            '''), file=sys.stderr)
         traceback.print_exc(e)
 
 
@@ -105,8 +105,9 @@ def process_dmd_files_impl(dmd_files, args):
             outfile_name = 'processed-' + basename
 
         outfile = GzipFile(os.path.join(out_dir, outfile_name), 'w')
-        def write(str):
-            print(str, file=outfile)
+
+        def write(s):
+            print(s, file=outfile)
 
         write('# Processed DMD output')
         if creation_time:
@@ -152,13 +153,13 @@ def get_kgsl_files(out_dir):
         try:
             utils.pull_remote_file(remote_file, dest_file)
         except subprocess.CalledProcessError:
-            print('Unable to retrieve kgsl file: %s' % remote_file)
+            print('Unable to retrieve kgsl file: %s' % remote_file, file=sys.stderr)
 
     print('Done processing kgsl files.')
 
 
 def merge_files(dir, files):
-    '''Merge the given memory reporter dump files into one giant file.'''
+    """Merge the given memory reporter dump files into one giant file."""
     dumps = [json.load(GzipFile(os.path.join(dir, f))) for f in files]
 
     merged_dump = dumps[0]
@@ -167,12 +168,12 @@ def merge_files(dir, files):
         # dumps, otherwise we can't merge them.
         if set(dump.keys()) != set(merged_dump.keys()):
             print("Can't merge dumps because they don't have the "
-                  "same set of properties.")
+                  "same set of properties.", file=sys.stderr)
             return
         for prop in merged_dump:
             if prop != 'reports' and dump[prop] != merged_dump[prop]:
                 print("Can't merge dumps because they don't have the "
-                      "same value for property '%s'" % prop)
+                      "same value for property '%s'" % prop, file=sys.stderr)
 
         merged_dump['reports'] += dump['reports']
 
@@ -181,6 +182,7 @@ def merge_files(dir, files):
               open(merged_reports_path, 'w'),
               indent=2)
     return merged_reports_path
+
 
 def get_dumps(args):
     if args.output_directory:
@@ -217,6 +219,7 @@ def get_dumps(args):
                 [os.path.join(out_dir, f) for f in dmd_files])
 
     return utils.run_and_delete_dir_on_exception(do_work, out_dir)
+
 
 def get_and_show_info(args):
     (out_dir, merged_reports_path, dmd_files) = get_dumps(args)
@@ -275,30 +278,36 @@ def get_and_show_info(args):
 
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__,
+    parser = argparse.ArgumentParser(
+        description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
-    parser.add_argument('--minimize', '-m', dest='minimize_memory_usage',
+    parser.add_argument(
+        '--minimize', '-m', dest='minimize_memory_usage',
         action='store_true', default=False,
         help='Minimize memory usage before collecting the memory reports.')
 
-    parser.add_argument('--directory', '-d', dest='output_directory',
+    parser.add_argument(
+        '--directory', '-d', dest='output_directory',
         action='store', metavar='DIR',
         help=textwrap.dedent('''\
             The directory to store the reports in.  By default, we'll store the
             reports in the directory about-memory-N, for some N.'''))
 
-    parser.add_argument('--leave-on-device', '-l', dest='leave_on_device',
+    parser.add_argument(
+        '--leave-on-device', '-l', dest='leave_on_device',
         action='store_true', default=False,
         help='Leave the reports on the device after pulling them.')
 
-    parser.add_argument('--no-auto-open', '-o', dest='open_in_firefox',
+    parser.add_argument(
+        '--no-auto-open', '-o', dest='open_in_firefox',
         action='store_false', default=True,
         help=textwrap.dedent("""\
             By default, we try to open the memory report we fetch in Firefox.
             Specify this option prevent this."""))
 
-    parser.add_argument('--keep-individual-reports',
+    parser.add_argument(
+        '--keep-individual-reports',
         dest='keep_individual_reports',
         action='store_true', default=False,
         help=textwrap.dedent('''\
@@ -308,13 +317,15 @@ def main():
 
     gc_log_group = parser.add_mutually_exclusive_group()
 
-    gc_log_group.add_argument('--no-gc-cc-log',
+    gc_log_group.add_argument(
+        '--no-gc-cc-log',
         dest='get_gc_cc_logs',
         action='store_false',
         default=True,
         help="Don't get a gc/cc log.")
 
-    gc_log_group.add_argument('--abbreviated-gc-cc-log',
+    gc_log_group.add_argument(
+        '--abbreviated-gc-cc-log',
         dest='abbreviated_gc_cc_log',
         action='store_true',
         default=False,
@@ -325,10 +336,12 @@ def main():
                         default=False,
                         help='''Don't get the kgsl graphics memory logs.''')
 
-    parser.add_argument('--no-dmd', action='store_true', default=False,
+    parser.add_argument(
+        '--no-dmd', action='store_true', default=False,
         help='''Don't process DMD logs, even if they're available.''')
 
-    dmd_group = parser.add_argument_group('optional DMD args (passed to fix_b2g_stack)',
+    dmd_group = parser.add_argument_group(
+        'optional DMD args (passed to fix_b2g_stack)',
         textwrap.dedent('''\
             You only need to worry about these options if you're running DMD on
             your device.  These options get passed to fix_b2g_stack.'''))

--- a/tools/get_gc_cc_log.py
+++ b/tools/get_gc_cc_log.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 import sys
 if sys.version_info < (2,7):
     # We need Python 2.7 because we import argparse.
-    print('This script requires Python 2.7.')
+    print('This script requires Python 2.7.', file=sys.stderr)
     sys.exit(1)
 
 import os
@@ -58,7 +58,7 @@ def compress_logs(log_filenames, out_dir):
     for (filename, proc) in compression_procs:
         proc.wait()
         if proc.returncode:
-            print('Compression of %s failed!' % filename)
+            print('Compression of %s failed!' % filename, file=sys.stderr)
             raise subprocess.CalledProcessError(proc.returncode,
                                                 [compression_prog, filename],
                                                 None)

--- a/tools/include/device_utils.py
+++ b/tools/include/device_utils.py
@@ -1,4 +1,4 @@
-'''Utilities for interacting with a remote device.'''
+"""Utilities for interacting with a remote device."""
 
 from __future__ import print_function
 from __future__ import division
@@ -10,8 +10,9 @@ import subprocess
 import textwrap
 from time import sleep
 
+
 def remote_shell(cmd, verbose=True):
-    '''Run the given command on on the device and return stdout.  Throw an
+    """Run the given command on on the device and return stdout.  Throw an
     exception if the remote command returns a non-zero return code.
 
     Don't use this command for programs included in /system/bin/toolbox, such
@@ -21,7 +22,7 @@ def remote_shell(cmd, verbose=True):
     ourselves, we echo $? after running the command and then strip that off
     before returning the command's output.
 
-    '''
+    """
     out = shell(r"""adb shell '%s; echo -n "|$?"'""" % cmd)
 
     # The final '\n' in |out| separates the command output from the return
@@ -40,8 +41,9 @@ def remote_shell(cmd, verbose=True):
 
     raise subprocess.CalledProcessError(retcode, cmd, cmd_out)
 
+
 def remote_toolbox_cmd(cmd, args='', verbose=True):
-    '''Run the given command from /system/bin/toolbox on the device.  Pass
+    """Run the given command from /system/bin/toolbox on the device.  Pass
     args, if specified, and return stdout.  Throw an exception if the command
     returns a non-zero return code.
 
@@ -54,20 +56,22 @@ def remote_toolbox_cmd(cmd, args='', verbose=True):
     busybox is installed on the system.  This will ensure that we get
     the same output regardless of whether busybox is installed.
 
-    '''
+    """
     return remote_shell('/system/bin/toolbox "%s" %s' % (cmd, args), verbose)
 
+
 def remote_ls(dir, verbose=True):
-    '''Run ls on the remote device, and return a set containing the results.'''
+    """Run ls on the remote device, and return a set containing the results."""
     return {f.strip() for f in remote_toolbox_cmd('ls', dir, verbose).split('\n')}
 
+
 def shell(cmd, cwd=None, show_errors=True):
-    '''Run the given command as a shell script on the host machine.
+    """Run the given command as a shell script on the host machine.
 
     If cwd is specified, we run the command from that directory; otherwise, we
     run the command from the current working directory.
 
-    '''
+    """
     proc = subprocess.Popen(cmd, shell=True, cwd=cwd,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (out, err) = proc.communicate()
@@ -80,12 +84,13 @@ def shell(cmd, cwd=None, show_errors=True):
         raise subprocess.CalledProcessError(proc.returncode, cmd, err)
     return out
 
+
 def create_specific_output_dir(out_dir):
-    '''Create the given directory if it doesn't exist.
+    """Create the given directory if it doesn't exist.
 
     Throw an exception if a non-directory file exists with the same name.
 
-    '''
+    """
     if os.path.exists(out_dir):
         if os.path.isdir(out_dir):
             # Directory already exists; we're all good.
@@ -96,8 +101,9 @@ def create_specific_output_dir(out_dir):
                 directory already exists with that name.''' % out_dir))
     os.mkdir(out_dir)
 
+
 def create_new_output_dir(out_dir_prefix):
-    '''Create a new directory whose name begins with out_dir_prefix.'''
+    """Create a new directory whose name begins with out_dir_prefix."""
     for i in range(0, 1024):
         try:
             dir = '%s%d' % (out_dir_prefix, i)
@@ -107,12 +113,13 @@ def create_new_output_dir(out_dir_prefix):
             pass
     raise Exception("Couldn't create output directory.")
 
+
 def get_remote_b2g_pids():
-    '''Get the pids of all gecko processes running on the device.
+    """Get the pids of all gecko processes running on the device.
 
     Returns a tuple (master_pid, child_pids), where child_pids is a list.
 
-    '''
+    """
     procs = remote_toolbox_cmd('ps').split('\n')
     master_pid = None
     child_pids = []
@@ -129,22 +136,24 @@ def get_remote_b2g_pids():
 
     return (master_pid, child_pids)
 
+
 def pull_procrank_etc(out_dir):
-    '''Get the output of procrank and a few other diagnostic programs and save
+    """Get the output of procrank and a few other diagnostic programs and save
     it into out_dir.
 
-    '''
+    """
     shell('adb shell b2g-info > b2g-info', cwd=out_dir)
     shell('adb shell procrank > procrank', cwd=out_dir)
     shell('adb shell b2g-ps > b2g-ps', cwd=out_dir)
     shell('adb shell b2g-procrank > b2g-procrank', cwd=out_dir)
 
+
 def run_and_delete_dir_on_exception(fun, dir):
-    '''Run the given function and, if it throws an exception, delete the given
+    """Run the given function and, if it throws an exception, delete the given
     directory, if it's empty, before re-throwing the exception.
 
     You might want to wrap your call to send_signal_and_pull_files in this
-    function.'''
+    function."""
     try:
         return fun()
     except:
@@ -163,6 +172,7 @@ def run_and_delete_dir_on_exception(fun, dir):
         # Raise the original exception.
         raise exception_info[1], None, exception_info[2]
 
+
 def notify_and_pull_files(outfiles_prefixes,
                           remove_outfiles_from_device,
                           out_dir,
@@ -170,7 +180,7 @@ def notify_and_pull_files(outfiles_prefixes,
                           fifo_msg=None,
                           signal=None,
                           ignore_nuwa=os.getenv("MOZ_IGNORE_NUWA_PROCESS")):
-    '''Send a message to the main B2G process (either by sending it a signal or
+    """Send a message to the main B2G process (either by sending it a signal or
     by writing to a fifo that it monitors) and pull files created as a result.
 
     Exactly one of fifo_msg or signal must be non-null; otherwise, we throw
@@ -201,9 +211,9 @@ def notify_and_pull_files(outfiles_prefixes,
     device.  If that succeeds, we then pull all files which match
     optional_outfiles_prefixes.
 
-    '''
+    """
 
-    if (fifo_msg == None) == (signal == None):
+    if (fifo_msg is None) == (signal is None):
         raise ValueError("Exactly one of the fifo_msg and "
                          "signal kw args must be non-null.")
 
@@ -215,7 +225,7 @@ def notify_and_pull_files(outfiles_prefixes,
     child_pids = set(child_pids)
     old_files = _list_remote_temp_files(outfiles_prefixes + unified_outfiles_prefixes)
 
-    if signal != None:
+    if signal:
         _send_remote_signal(signal, master_pid)
     else:
         _write_to_remote_file('/data/local/debug_info_trigger', fifo_msg)
@@ -243,8 +253,8 @@ def notify_and_pull_files(outfiles_prefixes,
         if files_gotten >= files_expected:
             print('')
             if files_gotten > files_expected:
-                print("WARNING: Got more files than expected!")
-                print("(Is MOZ_IGNORE_NUWA_PROCESS set incorrectly?)")
+                print("WARNING: Got more files than expected!", file=sys.stderr)
+                print("(Is MOZ_IGNORE_NUWA_PROCESS set incorrectly?)", file=sys.stderr)
             break
 
         sleep(wait_interval)
@@ -255,16 +265,16 @@ def notify_and_pull_files(outfiles_prefixes,
         dead_child_pids = child_pids - set(get_remote_b2g_pids()[1])
         if len(dead_child_pids):
             for pid in dead_child_pids:
-                print("\rWarning: Child %u exited during memory reporting" % pid)
+                print("\rWarning: Child %u exited during memory reporting" % pid, file=sys.stderr)
             child_pids -= dead_child_pids
             num_expected_files -= len(outfiles_prefixes) * len(dead_child_pids)
 
     if files_gotten < files_expected:
         print('')
-        print("We've waited %ds but the only relevant files we see are" % max_wait)
-        print('\n'.join(['  ' + f for f in new_files | new_unified_files]))
+        print("We've waited %ds but the only relevant files we see are" % max_wait, file=sys.stderr)
+        print('\n'.join(['  ' + f for f in new_files | new_unified_files]), file=sys.stderr)
         print('We expected %d but see only %d files.  Giving up...' %
-              (files_expected, files_gotten))
+              (files_expected, files_gotten), file=sys.stderr)
         raise Exception("Unable to pull some files.")
 
     new_files = _pull_remote_files(all_outfiles_prefixes, old_files, out_dir)
@@ -282,18 +292,19 @@ def pull_remote_file(remote_file, dest_file):
 # but hey, maybe you do.
 
 def _send_remote_signal(signal, pid):
-    '''Send a signal to a process on the device.
+    """Send a signal to a process on the device.
 
     signal can be either an integer or a string of the form 'SIGRTn' where n is
     an integer.  We interpret SIGRTn to mean the signal SIGRTMIN + n.
 
-    '''
+    """
     # killer is a program we put on the device which is like kill(1), except it
     # accepts signals above 31.  It also understands "SIGRTn" per above.
     remote_shell("killer %s %d" % (signal, pid))
 
+
 def _write_to_remote_file(file, msg):
-    '''Write a message to a file on the device.
+    """Write a message to a file on the device.
 
     Note that echo is a shell built-in, so we use remote_shell, not
     remote_toolbox_cmd, here.
@@ -301,12 +312,13 @@ def _write_to_remote_file(file, msg):
     Also, due to ghetto string escaping in remote_shell, we must use " and not
     ' in this command.
 
-    '''
+    """
     remote_shell('echo -n "%s" > "%s"' % (msg, file))
 
+
 def _list_remote_temp_files(prefixes):
-    '''Return a set of absolute filenames in the device's temp directory which
-    start with one of the given prefixes.'''
+    """Return a set of absolute filenames in the device's temp directory which
+    start with one of the given prefixes."""
 
     # Look for files in both /data/local/tmp/ and
     # /data/local/tmp/memory-reports.  New versions of b2g dump everything into
@@ -323,13 +335,14 @@ def _list_remote_temp_files(prefixes):
 
     return found_files
 
+
 def _pull_remote_files(outfiles_prefixes, old_files, out_dir):
-    '''Pull files from the remote device's temp directory into out_dir.
+    """Pull files from the remote device's temp directory into out_dir.
 
     We pull each file in the temp directory whose name begins with one of the
     elements of outfiles_prefixes and which isn't listed in old_files.
 
-    '''
+    """
     new_files = _list_remote_temp_files(outfiles_prefixes) - old_files
     for f in new_files:
         shell('adb pull %s' % f, cwd=out_dir)
@@ -337,13 +350,14 @@ def _pull_remote_files(outfiles_prefixes, old_files, out_dir):
     print("Pulled files into %s." % out_dir)
     return new_files
 
+
 def _remove_files_from_device(outfiles_prefixes, old_files):
-    '''Remove files from the remote device's temp directory.
+    """Remove files from the remote device's temp directory.
 
     We remove all files starting with one of the elements of outfiles_prefixes
     which aren't listed in old_files.
 
-    '''
+    """
     files_to_remove = _list_remote_temp_files(outfiles_prefixes) - old_files
 
     for f in files_to_remove:


### PR DESCRIPTION
Part 0 neurotically cleans up some PEP violations. Not a big deal, but it seemed like a good time to do some more cleanup (and it makes my editor happy).

Part 1 is the real change, it primarily just adds file=sys.stderr to error print statements.
