### PR TITLE
Bug 1048819 - Make --sdk-version optionnal, with a default of ICS

### DIFF
--- a/tools/update-tools/build-flash-fota.py
+++ b/tools/update-tools/build-flash-fota.py
@@ -112,8 +112,8 @@ def main():
         help="Specify update-binary to be used in update.zip.")
 
     parser.add_argument("-s", "--sdk-version", dest="sdk_version",
-        required=True, default=-1, type=int,
-        help="Specify the target SDK version when producing update.zip.")
+        required=False, default=15, type=int,
+        help="Specify the target SDK version (defaulting to SDK 15, ICS) when producing update.zip.")
 
     parser.add_argument("-o", "--output", dest="output", metavar="ZIP",
         help="Output to ZIP. Default: flash.zip", default=None)


### PR DESCRIPTION
With bug 1047350 we introduced a new mandatory option (--sdk-version) in
the script buildinf the FOTA package. However, this is living in B2G/
which is not branched. The calling code that passes the argument lives
in gonk-misc/ which is branched. This makes it possible to have all
repos uptodate and not sync thus causing bug 1048819. We make the option
non mandatory and we default it to ICS.
