### PR TITLE
Bug 1019638 - Disabling DMD after enabling DMD doesn't stop DMD from run...

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -246,8 +246,9 @@ delete_extra_gecko_files_on_device()
 		#    you squint at files_to_remove, you'll see that it will
 		#    contain files which are on the host but not on the device;
 		#    obviously we can't remove those files from the device).
-
-		run_adb shell "cd /system/b2g && rm $files_to_remove" > /dev/null
+		for to_remove in $files_to_remove; do
+			run_adb shell "rm /system/b2g/$to_remove" > /dev/null
+		done
 	fi
 	return 0
 }


### PR DESCRIPTION
...ning

It would appear that the `adb shell rm` command was bailing early rather than deleting all files.
