### PR TITLE
Bug 1069017 - Add a flash.sh target to flash gecko and gaia.

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -330,6 +330,17 @@ while [ $# -gt 0 ]; do
 done
 
 case "$PROJECT" in
+"shallow")
+	run_adb shell stop b2g &&
+	run_adb remount &&
+	flash_gecko &&
+	flash_gaia &&
+	update_time &&
+	echo Restarting B2G &&
+	run_adb shell start b2g
+	exit $?
+	;;
+
 "gecko")
 	run_adb shell stop b2g &&
 	run_adb remount &&


### PR DESCRIPTION
This is useful when updating a tree to current source and reflashing.
It's useful to have a single target for two reasons:

 (1) it saves waiting for the device to reboot and typing another
     command.

 (2) there's code that runs at startup to reregister gaia apps when the
     gecko version or build id changes.  If you reflash gecko, reboot,
     and then flash gaia, this code doesn't get invoked correctly with
     the new gaia.  See
     https://hg.mozilla.org/mozilla-central/file/4f2cac8d72da/dom/apps/AppsUtils.jsm#l482
     and its callers.
