### PR TITLE
Bug 1080445 - fix default xre_path for latest B2G SDK. r=jgriffin

### DIFF
--- a/tools/mach_b2g_bootstrap.py
+++ b/tools/mach_b2g_bootstrap.py
@@ -240,9 +240,7 @@ def bootstrap(b2g_home):
     xre_path = None
     gaia_dir = os.path.join(b2g_home, 'gaia')
     if os.path.isdir(gaia_dir):
-        xre_path = os.path.join(_find_xulrunner_sdk(gaia_dir), 'bin')
-        if sys.platform.startswith('darwin'):
-            xre_path = os.path.join(xre_path, 'XUL.framework', 'Versions', 'Current')
+        xre_path = os.path.join(_find_xulrunner_sdk(gaia_dir), 'b2g')
 
     def get_build_var(name):
         env = os.environ.copy()


### PR DESCRIPTION
B2G SDK has been moved to gaia/b2g_sdk/{sdk-version}/b2g.
