### PR TITLE
Bug 1085525 - |profile-symbolicate.py| expects proper python to be in |/...

### DIFF
--- a/scripts/profile-symbolicate.py
+++ b/scripts/profile-symbolicate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import argparse, bisect, json, os, subprocess, sys
 import os.path, re, requests


### PR DESCRIPTION
...usr/bin|
