### PR TITLE
Bug 1100812 - Run adb root internally

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -343,6 +343,8 @@ case "$PROJECT" in
 	;;
 
 "gecko")
+	resp=`run_adb root` || exit $?
+	[ "$resp" != "adbd is already running as root" ] && run_adb wait-for-device
 	run_adb shell stop b2g &&
 	run_adb remount &&
 	flash_gecko &&


### PR DESCRIPTION
When flashing gecko go root before remount
