### PR TITLE
Bug 1084041 - Remove files after applying FOTA r=gsvelto

### DIFF
--- a/tools/update-tools/build-flash-fota.py
+++ b/tools/update-tools/build-flash-fota.py
@@ -46,6 +46,8 @@ def build_flash_fota(args):
 	builder.fota_dirs = args.fota_dirs.split(' ')
         builder.fota_files = [line.rstrip() for line in open(args.fota_files, 'r')]
 
+    builder.fota_sdcard = args.fota_sdcard or "/sdcard"
+
     builder.fota_check_device_name = args.fota_check_device_name
     builder.fota_check_gonk_version = args.fota_check_gonk_version
     builder.system_dir = args.system_dir
@@ -84,6 +86,9 @@ def main():
     fota_group.add_argument("--fota-files", dest="fota_files",
         required=False, default="",
         help="file containing list of files in /system to include")
+    fota_group.add_argument("--fota-sdcard", dest="fota_sdcard",
+        required=False, default="/sdcard",
+        help="sdcard mountpoint in recovery mode (RECOVERY_EXTERNAL_STORAGE)")
 
     fota_checks_group = parser.add_argument_group("fota_checks_group")
     fota_checks_group.add_argument("--fota-check-device-name", dest="fota_check_device_name",

--- a/tools/update-tools/update_tools.py
+++ b/tools/update-tools/update_tools.py
@@ -937,6 +937,21 @@ class FlashFotaBuilder(object):
         self.generator.script.append(cmd)
         self.generator.Print("Device is compatible")
 
+    def CleanUpdateFiles(self):
+        """
+        Cleaning all the temporary files used for update
+        """
+
+        # delete_recursive() function in edify can handle files and
+        # directories.
+        staleUpdateFiles = [
+          os.path.join("/data", "local", "b2g-updates"),
+          os.path.join(self.fota_sdcard, "updates", "fota")
+        ]
+        self.generator.Print("Cleaning FOTA files")
+        self.generator.DeleteFilesRecursive(staleUpdateFiles)
+        self.generator.Print("FOTA files removed")
+
     def Umount(self, mount_point):
         """
            Unmounting a mount point. We cannot do it against a device directly.
@@ -1086,6 +1101,11 @@ class FlashFotaBuilder(object):
 
         self.generator.Print("Setting file permissions")
         self.build_permissions()
+
+        cmd = ('set_progress(0.9);')
+        self.generator.script.append(self.generator._WordWrap(cmd))
+        self.generator.Print("Cleaning update files")
+        self.CleanUpdateFiles()
 
         if self.fota_type == 'partial':
             cmd = ('else ui_print("Restoring previous stale update."); endif;')


### PR DESCRIPTION
We should not have any leftover files after applying a FOTA package
update, so we should ensure we are removing them at the end of the
process:
 - MAR package that has been extracted to /data/local/...
 - update.zip that has been extracted to the sdcard for applying in
   recovery mode