### PR TITLE
Bug 1116074: add emulator-l and emulator-x86-l

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -173,13 +173,13 @@ case "$1" in
 	repo_sync $1
 	;;  
 
-"emulator"|"emulator-jb"|"emulator-kk")
+"emulator"|"emulator-jb"|"emulator-kk"|"emulator-l")
 	echo DEVICE=generic >> .tmp-config &&
 	echo LUNCH=full-eng >> .tmp-config &&
 	repo_sync $1
 	;;
 
-"emulator-x86"|"emulator-x86-jb"|"emulator-x86-kk")
+"emulator-x86"|"emulator-x86-jb"|"emulator-x86-kk"|"emulator-x86-l")
 	echo DEVICE=generic_x86 >> .tmp-config &&
 	echo LUNCH=full_x86-eng >> .tmp-config &&
 	repo_sync $1
@@ -232,9 +232,11 @@ case "$1" in
 	echo - emulator
 	echo - emulator-jb
 	echo - emulator-kk
+	echo - emulator-l
 	echo - emulator-x86
 	echo - emulator-x86-jb
 	echo - emulator-x86-kk
+	echo - emulator-x86-l
 	exit -1
 	;;
 esac


### PR DESCRIPTION
This pr add two new emulator targets __emulator-l__ and __emulator-x86-l__. Please see [bug 1116074](https://bugzilla.mozilla.org/show_bug.cgi?id=1116074) for more information.