### PR TITLE
Bug 1140225 - Close multiprocessing pool after use. r=mccr8

### DIFF
--- a/tools/get_gc_cc_log.py
+++ b/tools/get_gc_cc_log.py
@@ -59,6 +59,7 @@ def compress_logs(log_filenames, out_dir):
     # Start compressing.
     pool = Pool()
     pool.map(gzip_compress, to_compress)
+    pool.close()
 
 
 def get_logs(args, out_dir=None, get_procrank_etc=True):


### PR DESCRIPTION
Even though the pool goes out of scope, all of it's processes remain
open. Then the next time through we open even more processes which will
eventually lead to an OOM crash.