### PR TITLE
Bug 1134722: Use aries instead of shinano manifest file.

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -202,7 +202,7 @@ case "$1" in
 
 "aries")
 	echo PRODUCT_NAME=aries >> .tmp-config &&
-	repo_sync shinano
+	repo_sync aries
 	;;
 
 *)


### PR DESCRIPTION
This allows mozharness to build aries device. Mozharness takes the
manifest from the gecko tree, and expects the manifest file name be the
same as the target name.