### PR TITLE
Bug 1150397 - Temporarily bring wasabi back

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -115,7 +115,7 @@ case "$1" in
 	repo_sync $1
 	;;
 
-"otoro"|"unagi"|"keon"|"inari"|"leo"|"hamachi"|"peak"|"helix"|"flatfish")
+"otoro"|"unagi"|"keon"|"inari"|"leo"|"hamachi"|"peak"|"helix"|"wasabi"|"flatfish")
 	echo DEVICE=$1 >> .tmp-config &&
 	repo_sync $1
 	;;

--- a/flash.sh
+++ b/flash.sh
@@ -391,7 +391,7 @@ case "$DEVICE" in
 	exit $?
 	;;
 
-"flame"|"otoro"|"unagi"|"keon"|"peak"|"inari"|"flatfish"|"shinano"|"aries"|"scx15_sp7715"*)
+"flame"|"otoro"|"unagi"|"keon"|"peak"|"inari"|"wasabi"|"flatfish"|"shinano"|"aries"|"scx15_sp7715"*)
 	flash_fastboot nounlock $PROJECT
 	;;
 


### PR DESCRIPTION
Apparently the RIL team is still using it. This brings wasabi back until we can upgrade them to something more modern.