### PR TITLE
Fix python version problem

### DIFF
--- a/repo
+++ b/repo
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 ## repo default configuration
 ##


### PR DESCRIPTION
Works fine on arch
Work on:
Ubuntu 10.04 and newer
Debian 6 and newer
Fedora 22 and newer (I dont have any old fedora (; )
Not work on:
Debian 5
