### PR TITLE
Bug 1172813 - Catch the case which string is 0x prefixed but can't co…

### DIFF
--- a/scripts/profile-symbolicate.py
+++ b/scripts/profile-symbolicate.py
@@ -383,7 +383,10 @@ class Libraries:
       for thread in self.profile["threads"]:
         for str in thread["stringTable"]:
           if str[:2] == "0x":
-            yield int(str, 0)
+            try:
+              yield int(str, 0)
+            except ValueError:
+              continue
 
     if self.profile["meta"]["version"] >= 3:
       addresses = getUnresolvedAddressesV3()


### PR DESCRIPTION
…nvert to integer. r=dhylands