### PR TITLE
Bug 1177458 - Add 'ci' category to mach_b2g_bootstrap.py, r=jgriffin

### DIFF
--- a/tools/mach_b2g_bootstrap.py
+++ b/tools/mach_b2g_bootstrap.py
@@ -77,6 +77,11 @@ CATEGORIES = {
         'long': 'Run tests.',
         'priority': 60,
     },
+    'ci': {
+        'short': 'CI',
+        'long': 'Taskcluster commands',
+        'priority': 59
+    },
     'devenv': {
         'short': 'Development Environment',
         'long': 'Set up and configure your development environment.',


### PR DESCRIPTION
This won't actually show up in |mach help| because there are no commands that work with B2G in that category, but it's needed to fix the exception.