### PR TITLE
Bug 1214449 - Run adb as root for shallow flash.

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -341,6 +341,8 @@ done
 
 case "$PROJECT" in
 "shallow")
+	resp=`run_adb root` || exit $?
+	[ "$resp" != "adbd is already running as root" ] && run_adb wait-for-device
 	run_adb shell stop b2g &&
 	run_adb remount &&
 	flash_gecko &&


### PR DESCRIPTION
Bug 1100812 added a root escalation step to the gecko flash target.
This is also needed by the shallow flash target which flashes both
gecko and gaia.