### PR TITLE
Bug 1288035 - To check the missing PID of "run-gdb.sh attach" clearly. r?mwu

### DIFF
--- a/run-gdb.sh
+++ b/run-gdb.sh
@@ -114,8 +114,8 @@ if [ "$1" != "core" ] ; then
 fi
 
 if [ "$1" = "attach" ]; then
-   if [ -z "$B2G_PID" ]; then
-      echo Error: No PID to attach to. B2G not running?
+   if [ "$#" == "1"  ]; then
+      echo Error: No PID is specified. \(./run-gdb.sh attach PID\)
       exit 1
    fi
 


### PR DESCRIPTION
[1] is the code to validate the argument 2 - PID and will exit execution if PID is wrong. Therefore [2] is no necessary to check PID again. The only possible failure case here is user doesn't specify argument 2 so I changed the check here and leave more clear error message.

[1] https://github.com/mozilla-b2g/B2G/blob/master/run-gdb.sh#L90
[2] https://github.com/mozilla-b2g/B2G/blob/master/run-gdb.sh#L117
